### PR TITLE
chore: broken link removed

### DIFF
--- a/2.python/README.md
+++ b/2.python/README.md
@@ -13,7 +13,3 @@ See above or click links:
 - [Sun Detector](sun-detector/)
 - [War Games](war-games/)
 - [Archive](z_archive/)
-
-## Scripts To Overhaul
-
-- [Scripts To Overhaul](/python/scripts-to-overhaul/)


### PR DESCRIPTION
Link removed because already exists in first section.